### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -6,6 +6,10 @@ on:
     tags-ignore:
       - "*"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pull_request:
     if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/innago-property-management/redirect-server/security/code-scanning/1](https://github.com/innago-property-management/redirect-server/security/code-scanning/1)

To fix the problem, we need to add a minimal `permissions` block to the workflow definition. This block can be added either at the top level (applying to all jobs) or within the individual job (here only `pull_request`). Given that the job uses a reusable workflow to create pull requests, the least privilege required typically includes `contents: read` (so the workflow can read repository content) and `pull-requests: write` (to be able to open/modify pull requests). The change should be added above the `jobs:` key in `.github/workflows/auto-pr.yml`. No other modifications are required elsewhere; simply adding the permissions is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add minimal permissions block to GitHub Actions auto-pr workflow granting contents: read and pull-requests: write